### PR TITLE
Seed manual offers and allow-list debug mode

### DIFF
--- a/public/data/cloudflare_offers.json
+++ b/public/data/cloudflare_offers.json
@@ -1,26 +1,68 @@
 [
   {
-    "name": "iOS Cash App",
-    "url": "https://tracking.com?id=xyz",
-    "geo": ["US"],
-    "device": "iOS",
-    "payout": 2.5,
-    "tags": ["mobile", "Reddit-safe"]
-  },
-  {
-    "name": "Android Survey",
-    "url": "https://tracking.com?id=abc",
-    "geo": ["US", "CA"],
-    "device": "Android",
-    "payout": 1.2,
-    "tags": ["mobile"]
-  },
-  {
-    "name": "Desktop Crypto",
-    "url": "https://tracking.com?id=def",
+    "name": "US Desktop – Test",
+    "network": "Manual",
+    "url": "https://www.apple.com/",
     "geo": ["US"],
     "device": "Desktop",
-    "payout": 3.0,
-    "tags": ["desktop"]
+    "payout": 2.50,
+    "category": "Test",
+    "tags": ["manual","safe"],
+    "active": true
+  },
+  {
+    "name": "US Android – Test",
+    "network": "Manual",
+    "url": "https://play.google.com/store",
+    "geo": ["US"],
+    "device": "Android",
+    "payout": 1.80,
+    "category": "Test",
+    "tags": ["manual","mobile"],
+    "active": true
+  },
+  {
+    "name": "US iOS – Test",
+    "network": "Manual",
+    "url": "https://apps.apple.com/us",
+    "geo": ["US"],
+    "device": "iOS",
+    "payout": 2.10,
+    "category": "Test",
+    "tags": ["manual","mobile"],
+    "active": true
+  },
+  {
+    "name": "UK iOS – Test",
+    "network": "Manual",
+    "url": "https://apps.apple.com/gb",
+    "geo": ["UK"],
+    "device": "iOS",
+    "payout": 2.20,
+    "category": "Test",
+    "tags": ["manual","mobile"],
+    "active": true
+  },
+  {
+    "name": "Weekend Desktop – Test",
+    "network": "Manual",
+    "url": "https://www.microsoft.com/",
+    "geo": ["ALL"],
+    "device": "Desktop",
+    "payout": 1.00,
+    "category": "Test",
+    "tags": ["manual"],
+    "active": true
+  },
+  {
+    "name": "Fallback – All GEO/Devices",
+    "network": "Manual",
+    "url": "https://www.wikipedia.org/",
+    "geo": ["ALL"],
+    "device": "ALL",
+    "payout": 0.10,
+    "category": "Test",
+    "tags": ["fallback"],
+    "active": true
   }
 ]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,3 +16,4 @@ id = "59e608056956435ba9288a0866d82df9"
 
 [vars]
 OFFERS_PATH = "/data/cloudflare_offers.json"
+ALLOWED_HOSTS = "apple.com,play.google.com,apps.apple.com,microsoft.com,wikipedia.org"


### PR DESCRIPTION
## Summary
- seed manual Cloudflare offers data for local testing
- allow-list redirect hosts and expose debug info
- ensure /sv responses are noindex/nofollow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

## Manual Testing
1. `npx wrangler dev --local`
2. Visit `http://localhost:8787/sv?utm_source=reddit&utm_medium=cpc&utm_campaign=test&utm_content=A&debug=1`
3. Visit `http://localhost:8787/sv?device=Android&debug=1`
4. Visit `http://localhost:8787/sv?device=iOS&debug=1`
5. Visit `http://localhost:8787/sv?device=iOS&country=UK&debug=1`
6. Confirm debug output selects a manual offer with no host blocking messages
7. Remove `debug=1` and confirm a 302 to the same URL

------
https://chatgpt.com/codex/tasks/task_e_6897ab0c7dac832f9686b17b06226f74