### PR TITLE
Add tests for offers validation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "build": "wrangler build"
+    "build": "wrangler build",
+    "test": "node --test scripts/__tests__/validate_offers.test.mjs"
   },
   "devDependencies": {
     "wrangler": "^4.27.0"

--- a/scripts/__tests__/validate_offers.test.mjs
+++ b/scripts/__tests__/validate_offers.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const dataPath = path.join(repoRoot, 'public/data/cloudflare_offers.json');
+const originalData = await fs.readFile(dataPath, 'utf8');
+
+function runValidator() {
+  return spawnSync('node', ['scripts/validate_offers.mjs'], { encoding: 'utf8' });
+}
+
+async function withData(data, fn) {
+  await fs.writeFile(dataPath, data);
+  try {
+    await fn();
+  } finally {
+    await fs.writeFile(dataPath, originalData);
+  }
+}
+
+test('valid data passes', async () => {
+  await withData(originalData, async () => {
+    const { status } = runValidator();
+    assert.strictEqual(status, 0);
+  });
+});
+
+test('missing fields fails', async () => {
+  const missingUrl = JSON.stringify([
+    { name: 'No URL', geo: ['US'], device: 'Desktop', payout: 1, active: true }
+  ], null, 2);
+  await withData(missingUrl, async () => {
+    const { status, stderr } = runValidator();
+    assert.notStrictEqual(status, 0);
+    assert.match(stderr, /missing required field "url"/);
+  });
+});
+
+test('invalid URL fails', async () => {
+  const invalidUrl = JSON.stringify([
+    { name: 'Bad URL', url: 'http://example.com', geo: ['US'], device: 'Desktop', payout: 1, active: true }
+  ], null, 2);
+  await withData(invalidUrl, async () => {
+    const { status, stderr } = runValidator();
+    assert.notStrictEqual(status, 0);
+    assert.match(stderr, /"url" must start with https:\/\//);
+  });
+});


### PR DESCRIPTION
## Summary
- add Node test suite for `validate_offers.mjs` covering valid data, missing fields, and invalid URLs
- expose npm `test` script using Node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c8d52658832fbf6e42b4b380e634